### PR TITLE
new registry url

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: ska-registry.av.it.pt/ska-docker/tango-builder:latest
+image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
 
 variables:
   DOCKER_DRIVER: overlay2

--- a/.make/Makefile.mk
+++ b/.make/Makefile.mk
@@ -22,7 +22,7 @@ endif
 RELEASE_SUPPORT := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/.make-release-support
 
 ifeq ($(strip $(DOCKER_REGISTRY_HOST)),)
-  DOCKER_REGISTRY_HOST = ska-registry.av.it.pt
+  DOCKER_REGISTRY_HOST = nexus.engageska-portugal.pt
 endif
 
 ifeq ($(strip $(DOCKER_REGISTRY_USER)),)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #ARG DOCKER_REGISTRY_HOST
 #FROM ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/ska-python-buildenv:latest AS buildenv
 #FROM ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/ska-python-runtime:latest AS runtime
-FROM ska-registry.av.it.pt/ska-docker/ska-python-buildenv:latest AS buildenv
-FROM ska-registry.av.it.pt/ska-docker/ska-python-runtime:latest AS runtime
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest AS buildenv
+FROM nexus.engageska-portugal.pt/ska-docker/ska-python-runtime:latest AS runtime
 
 #install lmc-base-classes
 # RUN apt install git

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 #
 # DOCKER_REGISTRY_HOST, DOCKER_REGISTRY_USER and PROJECT are combined to define
 # the Docker tag for this project. The definition below inherits the standard
-# value for DOCKER_REGISTRY_HOST (=rska-registry.av.it.pt) and overwrites
+# value for DOCKER_REGISTRY_HOST (=rnexus.engageska-portugal.pt) and overwrites
 # DOCKER_REGISTRY_USER and PROJECT to give a final Docker tag of
-# ska-registry.av.it.pt/dishmaster/dishmaster
+# nexus.engageska-portugal.pt/dishmaster/dishmaster
 #
 DOCKER_REGISTRY_USER:=tango-example
 PROJECT = dishmaster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ volumes:
 
 services:
   tangodb:
-    image: ska-registry.av.it.pt/ska-docker/tango-db:latest
+    image: nexus.engageska-portugal.pt/ska-docker/tango-db:latest
     depends_on:
       - rsyslog-dishmaster
     environment:
@@ -26,7 +26,7 @@ services:
       - tangodb:/var/lib/mysql
 
   databaseds:
-    image: ska-registry.av.it.pt/ska-docker/tango-cpp:latest
+    image: nexus.engageska-portugal.pt/ska-docker/tango-cpp:latest
     depends_on:
       - tangodb
     environment:


### PR DESCRIPTION
The docker registry has been migrated to the Nexus repository (nexus.engageska-portugal.pt) in order to have all repositories concentrated in one place. By that, ska-registry.av.it.pt will no longer be available.